### PR TITLE
Update Dockerfile to use the image from GCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM public.ecr.aws/docker/library/docker:20.10
+ARG UBUNTU_VERSION=22.04
+FROM mirror.gcr.io/ubuntu:${UBUNTU_VERSION}
 
 RUN apk add bash
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,6 @@ FROM mirror.gcr.io/ubuntu:${UBUNTU_VERSION}
 
 COPY entrypoint.sh /entrypoint.sh
 
+RUN apt install docker.io
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ FROM mirror.gcr.io/ubuntu:${UBUNTU_VERSION}
 
 COPY entrypoint.sh /entrypoint.sh
 
-RUN apt install docker.io
+RUN apt -y update && apt -y install docker.io
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 ARG UBUNTU_VERSION=22.04
 FROM mirror.gcr.io/ubuntu:${UBUNTU_VERSION}
 
-RUN apk add bash
-
 COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
We have run into the pull limits with Amazon ECR and switching to the Google Registry.

Also, taking the opportunity to bump the version of the container.